### PR TITLE
fix: logo link goes to products_path instead of homepage

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <div class="container-fluid">
-    <%= link_to "/#", class: "navbar-brand" do %>
+    <%= link_to products_path, class: "navbar-brand" do %>
       <%= image_tag "loopyex.png" %>
     <% end %>
     <% if user_signed_in? %>


### PR DESCRIPTION
just made a small change to the navbar so that the logo link takes us to the products index instead of the homepage which takes the user out of the marketplace.