### PR TITLE
fix: added cards to my orders page (orders#index view) and adjusted to…

### DIFF
--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -12,6 +12,7 @@ $font-size-base: 1rem;
 // Colors
 $body-color: $gray;
 $primary:    $gray-khaki;
+$secondary:  $medium-gray;
 $success:    $green;
 $info:       $rose-khaki;
 $danger:     $red;

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -7,5 +7,6 @@ $gray-khaki: #D6CCC2;
 $orange: #E67E22;
 $green: #10d863;
 $gray: rgb(69, 68, 68);
+$medium-gray: #c3c3bc;
 $light-gray: #F4F4F4;
 $red: rgb(255, 68, 0);

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -6,11 +6,9 @@
     </h1>
   </div>
 
-  <div class="container">
-    <ul>
-      <% @orders.each do |order| %>
-        <li><%= order.product.name %></li>
-      <% end %>
-    </ul>
+  <div class="cards d-flex flex-wrap justify-content-start" style="grid-template-columns: 1fr 1fr 1fr 1fr;">
+    <% @orders.each do |order| %>
+      <%= render 'shared/profile_card', product: order.product %>
+    <% end %>
   </div>
 </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -52,13 +52,17 @@
           <br><strong>Color:</strong> <%= @product.color.capitalize %></p>
           <p class="pe-5 mb-2"><%= @product.description %>
           <br>
-          
-          <% if @time_ago == 0 %>
-            <p class="fst-italic text-secondary">Added today</p>
-          <% elsif @time_ago == 1 %>
-            <p class="fst-italic text-secondary">Added 1 day ago</p>
+
+          <% if @product.order %>
+            <p class="fst-italic text-secondary"><%= @product.order.created_at.strftime('Purchased on %b %d %Y') %></p>
           <% else %>
-            <p class="fst-italic text-secondary">Added <%= @time_ago %> days ago</p>
+            <% if @time_ago == 0 %>
+              <p class="fst-italic text-secondary">Added today</p>
+            <% elsif @time_ago == 1 %>
+              <p class="fst-italic text-secondary">Added 1 day ago</p>
+            <% else %>
+              <p class="fst-italic text-secondary">Added <%= @time_ago %> days ago</p>
+            <% end %>
           <% end %>
         </div>
 

--- a/app/views/shared/_profile_card.html.erb
+++ b/app/views/shared/_profile_card.html.erb
@@ -1,5 +1,5 @@
 <%= link_to product_path(product) do %>
-  <div class="card" style="width:300px">
+  <div class="card profile" style="width:300px">
 
       <%= image_tag product.photos[0], class:"card-img-top img", style: "height:150px; object-fit:cover;"%>
 
@@ -10,6 +10,9 @@
       </div>
 
       <p class="card-text m-0"><%= product.brand %></p>
+      <% if product.order %>
+        <p class="card-text text-secondary"><%= product.order.created_at.strftime('Purchased on %b %d %Y') %></p>
+      <% end %>
 
       <% if current_user == product.user %>
         <div class="user-options-container d-flex flex-row justify-content-end">


### PR DESCRIPTION
added cards to my orders page (orders#index view) and adjusted to include purchase date (on profile_card and product#show page) added medium gray color for date text secondary color

<img width="568" alt="Screen Shot 2022-11-10 at 20 29 53" src="https://user-images.githubusercontent.com/59029920/201188759-3c0ddae5-85a8-4182-aae6-4e24fa4a2b40.png">
<img width="1508" alt="Screen Shot 2022-11-10 at 20 30 07" src="https://user-images.githubusercontent.com/59029920/201188778-5cc12ddd-beb1-48a6-acbc-4da06ffd8b06.png">
