### PR TITLE
feat: added a little active action on card to remove box shadow when …

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -19,6 +19,9 @@
   border-top-right-radius: 1rem;
   border-bottom-left-radius: 1rem;
   border-bottom-right-radius: 1rem;
+  &:active {
+    box-shadow: none;
+  }
 }
 
 .small_row {


### PR DESCRIPTION
added a little active action on all cards to remove box-shadow when clicked...gives the impression of pressing down maybe? Let me know what you think!