### PR TITLE
Product edit form created; needs work

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -41,8 +41,8 @@ class ProductsController < ApplicationController
   end
 
   def update
-    @product = Product.update(product_params)
-    redirect_to product_path(@product), notice: "Product updated successfully."
+    @product = @product.update(product_params)
+    # redirect_to product_path(@product), notice: "Product updated successfully."
   end
 
   def destroy

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,0 +1,51 @@
+<div class="new-product-form">
+  <div class = "container devise-card" id="productForm">
+    <div class = 'container-relative' >
+      <img src="https://images.unsplash.com/photo-1588676006059-956f7751dc31?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80"
+      class="img rounded-4 cover" alt="..." >
+      <div class="text-box">
+        <h2>Edit this product</h2>
+    </div>
+    </div>
+      <div id="inputFields">
+      <%= simple_form_for(@product) do |f| %>
+        <div class="form-input">
+          <%= f.input :name, input_html: { value: @product.name } %>
+          <%= f.input :brand, as: :select, collection:  ['Adriafil', 'Austermann', 'BC Garn', 'Bergere de France', 'Berroco', 'Caron',
+                                      'Cascade Yarns', 'DMC', 'Debbie Bliss', 'Drops', 'Istex', 'ITO', 'Katia',
+                                      'Knitting for Olive', 'Lana Grossa', 'Lang Yarns', 'Lion Brand', 'Malabrigo',
+                                      'Noro', 'Novita', 'Phildar', 'Rico', 'Rowan', 'Schachenmayr', 'Scheepjes',
+                                      'The Fibre Co.', 'Life in the Long Grass', 'Hobbii', 'Other'], selected: { value: params[:brand] } %>
+          <%= f.input :price, input_html: {min: '0.1', step: '0.1', value: @product.price } %>
+          <%= f.input :quantity, input_html: {min: '1', value: @product.quantity }, step: 'any' %>
+          <%= f.input :color, input_html: { value: @product.color } %>
+          <%= f.input :material, input_html: { value: @product.material } %>
+          <%= f.input :weight, as: :select, collection: ['Lace', 'Fingering', 'Sock', 'Sport', 'DK', 'Worsted', 'Aran',
+          'Chunky', 'Super Chunky', 'Bulky', 'Jumbo', 'Other'], selected: { value: params[:weight] } %>
+          <%= f.input :description, input_html: { value: @product.description }  %>
+          <%= f.input :address, input_html: { value: @product.address } %>
+          <%= f.input :photos, as: :file, input_html: { multiple: true } %>
+        </div>
+        <div class="form-actions">
+          <%= f.button :submit, "Update", class: "btn btn-gray" %>
+        </div>
+      <% end %>
+    </div>
+
+
+
+
+  <%# <h4>Delete product</h4> %>
+  <%# <p><%= link_to "Delete this product", product_path(product), data: { confirm: "Are you sure?" }, method: :delete %>
+
+    <div class="container">
+      <%= link_to "Back", :back %>
+    </div>
+  <br/>
+  <br/>
+
+    </div>
+  </div>
+
+
+</div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -52,7 +52,7 @@
           <br><strong>Color:</strong> <%= @product.color.capitalize %></p>
           <p class="pe-5 mb-2"><%= @product.description %>
           <br>
-          
+
           <% if @time_ago == 0 %>
             <p class="fst-italic text-secondary">Added today</p>
           <% elsif @time_ago == 1 %>


### PR DESCRIPTION
Product edit form created, and it works *_to a certain extent_*. 

What is still broken:
- I haven't figured out how to pre-populate the Photos field with the images that are already uploaded (or have them listed as current photos somehow)
- Editing the product deletes all of the attached photos
- Redirect after editing no longer working (the update method in product controller has an issue there) - see comment and screenshot below
- Other minor UX issues like where the 'Back' link is located, and the Delete this product function is currently commented out
- **FIXED**: Editing one product updates ALL products in the index

Sorry I am not able to continue working on this!

<img width="385" alt="Screenshot 2022-11-11 at 00 04 52" src="https://user-images.githubusercontent.com/58528404/201224596-3a8fb316-52ec-475a-92ba-65a3cbc8de42.png">

<img width="1419" alt="Screenshot 2022-11-11 at 00 02 13" src="https://user-images.githubusercontent.com/58528404/201224458-2d5d5f2b-b11d-450b-9573-47d96a4b9846.png">
<img width="1393" alt="Screenshot 2022-11-10 at 23 48 39" src="https://user-images.githubusercontent.com/58528404/201224464-88f3fd27-78eb-49c4-a35b-af660f3dd629.png">
