### PR TITLE
fixed issues with edit product user journey

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -17,8 +17,8 @@
 
   .cover{
     object-fit: cover;
-    margin-top: 1em;
-    margin-bottom: 1em;
+    max-height: 200px;
+    margin: 1em 0 1em 0;
   }
 }
 
@@ -86,4 +86,10 @@ abbr[title] {color: #cd6565;
 
 #quantity {
   width: 44%;
+}
+
+.mb-3 {
+  flex-grow: 1;
+  flex-wrap: wrap;
+  padding: 0 1em 0 1em;
 }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -10,10 +10,7 @@ class ProductsController < ApplicationController
     end
 
     @markers = @products.geocoded.map do |product|
-      {
-        lat: product.latitude,
-        lng: product.longitude
-      }
+      { lat: product.latitude, lng: product.longitude }
     end
   end
 
@@ -41,8 +38,11 @@ class ProductsController < ApplicationController
   end
 
   def update
-    @product = @product.update(product_params)
-    # redirect_to product_path(@product), notice: "Product updated successfully."
+    if @product.update(product_params)
+      redirect_to product_path(@product), notice: "Product updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy

--- a/app/javascript/activestorage.js
+++ b/app/javascript/activestorage.js
@@ -1,0 +1,2 @@
+import * as ActiveStorage from "@rails/activestorage"
+ActiveStorage.start()

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,9 @@
 
   <body>
     <%= render "shared/navbar" %>
-    <%# <p class="notice"><%= notice %></p>
-    <%# <p class="alert"><%= alert %></p>
+    <p class="notice"><%= notice %></p>
+    <p class="alert"><%= alert %></p>
+
     <%= yield %>
     <br />
     <%= render "shared/footer" %>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -9,41 +9,56 @@
     </div>
       <div id="inputFields">
       <%= simple_form_for(@product) do |f| %>
-        <div class="form-input">
-          <%= f.input :name, input_html: { value: @product.name } %>
-          <%= f.input :brand, as: :select, collection:  ['Adriafil', 'Austermann', 'BC Garn', 'Bergere de France', 'Berroco', 'Caron',
-                                      'Cascade Yarns', 'DMC', 'Debbie Bliss', 'Drops', 'Istex', 'ITO', 'Katia',
-                                      'Knitting for Olive', 'Lana Grossa', 'Lang Yarns', 'Lion Brand', 'Malabrigo',
-                                      'Noro', 'Novita', 'Phildar', 'Rico', 'Rowan', 'Schachenmayr', 'Scheepjes',
-                                      'The Fibre Co.', 'Life in the Long Grass', 'Hobbii', 'Other'], selected: { value: params[:brand] } %>
-          <%= f.input :price, input_html: {min: '0.1', step: '0.1', value: @product.price } %>
-          <%= f.input :quantity, input_html: {min: '1', value: @product.quantity }, step: 'any' %>
-          <%= f.input :color, input_html: { value: @product.color } %>
-          <%= f.input :material, input_html: { value: @product.material } %>
-          <%= f.input :weight, as: :select, collection: ['Lace', 'Fingering', 'Sock', 'Sport', 'DK', 'Worsted', 'Aran',
-          'Chunky', 'Super Chunky', 'Bulky', 'Jumbo', 'Other'], selected: { value: params[:weight] } %>
+        <div class="form-input p-0">
+          <div class="d-flex justify-content-between flex-wrap p-0 m-0">
+            <%= f.input :name, input_html: { value: @product.name } %>
+            <%= f.input :brand, as: :select, collection:  ['Adriafil', 'Austermann', 'BC Garn', 'Bergere de France', 'Berroco', 'Caron',
+                                        'Cascade Yarns', 'DMC', 'Debbie Bliss', 'Drops', 'Istex', 'ITO', 'Katia',
+                                        'Knitting for Olive', 'Lana Grossa', 'Lang Yarns', 'Lion Brand', 'Malabrigo',
+                                        'Noro', 'Novita', 'Phildar', 'Rico', 'Rowan', 'Schachenmayr', 'Scheepjes',
+                                        'The Fibre Co.', 'Life in the Long Grass', 'Hobbii', 'Other'],
+                        selected: { value: @product.brand } %>
+            </div>
+          <div class="d-flex justify-content-between flex-wrap p-0 m-0">
+            <%= f.input :price, label: "Price (€)", input_html: {min: '1', step: "1", value: @product.price } %>
+            <%= f.input :quantity, input_html: {min: '1', value: @product.quantity }, step: 'any' %>
+          </div>
+          <div class="d-flex justify-content-between flex-wrap p-0 m-0">
+            <%= f.input :color, input_html: { value: @product.color } %>
+            <%= f.input :material, input_html: { value: @product.material } %>
+            <%= f.input :weight, as: :select, collection: ['Lace', 'Fingering', 'Sock', 'Sport', 'DK', 'Worsted', 'Aran',
+                                                           'Chunky', 'Super Chunky', 'Bulky', 'Jumbo', 'Other'],
+                                                           selected: { value: @product.weight } %>
+          </div>
           <%= f.input :description, input_html: { value: @product.description }  %>
           <%= f.input :address, input_html: { value: @product.address } %>
-          <%= f.input :photos, as: :file, input_html: { multiple: true } %>
+
+          <div class="d-flex justify-content-center">
+            <% if @product.photos.attached? %>
+              <% @product.photos.each do |attach| %>
+                <%= cl_image_tag attach.key, width: 200, height: 150, crop: :fill, class: "mx-2 my-3 rounded-4" %>
+                <%= f.hidden_field :photos, value: attach.signed_id %>
+              <% end %>
+            <% end %>
+          </div>
+          <%= f.input :photos, multiple: true, label: false %>
+
         </div>
-        <div class="form-actions">
-          <%= f.button :submit, "Update", class: "btn btn-gray" %>
+        <div class="form-actions d-flex flex-column align-items-center">
+          <%= f.button :submit, "Update", class: "btn btn-success fw-bold text-white fs-5" %>
+          <%= link_to "Delete this product", product_path(@product),
+            data: { confirm: "Are you sure?" },
+            method: :delete,
+            class: "btn btn-info fw-bold text-white fs-5 mt-2" %>
         </div>
       <% end %>
     </div>
 
-
-
-
-  <%# <h4>Delete product</h4> %>
-  <%# <p><%= link_to "Delete this product", product_path(product), data: { confirm: "Are you sure?" }, method: :delete %>
-
-    <div class="container">
-      <%= link_to "Back", :back %>
+    <div class="container mt-3">
+      <%= link_to user_path(current_user) do %>
+       <h4><i class="fa-solid fa-backward"></i> Back to your stash</h4>
+      <% end %>
     </div>
-  <br/>
-  <br/>
-
     </div>
   </div>
 


### PR DESCRIPTION
For whatever reason, this was difficult to find a solution for, but the solution was relatively easy so I recommend taking a look  [here](https://stackoverflow.com/questions/50360307/active-storage-best-practice-to-retain-cache-uploaded-file-when-form-redisplays) if you are curious on how to "bring in" the files that are already attached to your objects. I'll make a list of the more noticeable changes made:

- Created a hidden field to include object photos that were previously attached. The user will also see thumbnails of these photos, but, for the moment, cannot delete them (we won't add this functionality at this stage)
- Update button (style changed) takes us to user's stash if successful, if not, we should go back to the edit form (hopefully with alerts for why the update did not work)
- Activated Delete and created a button. Upon delete, redirects to products#index view.
- Updated form appearance so that we can see more on one page. (We probably should have made this form more horizontal now that I think about it.) I don't know why name and brand have different widths than the other fields though...I made updates in the file itself and in the CSS file for form. (We can update the new form if you guys want by using the HTML from the edit form view)
- Added currency to the price label and changed increments to reflect our integer type for the price attribute.

![Screen Shot 2022-11-11 at 23 12 43](https://user-images.githubusercontent.com/59029920/201439504-3b0bc97d-370e-4447-86fe-4782348741a5.png)

